### PR TITLE
Tidy cafebaby

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,16 +3,24 @@ Operating system devloped for CMSI 387 at LMU
 
 # Setup directions:
 
-We are using [Arch Linux](http://archlinux.org) for this, 
+We are using [Arch Linux](http://archlinux.org) and Mac OS X for this,
 so the directions are targeted towards that OS.
 
 ## Prerequisites:
 
+Arch:
 ```bash
 # pacman -S base-devel nasm cdrkit bochs multilib-devel
 ```
+Mac:
+* Xcode with command line tools
+* [Homebrew](http://brew.sh)
+```bash
+$ brew install nasm cdrtools bochs
+```
+NB: our cross-compiler compiled fine for me using clang, your mileage may vary. I have a lot of other libs on my system, not sure which are needed.
 
-`cdrkit` provides `genisoimage` and `bochs` includes the
+`cdrtools` provides `genisoimage` and `bochs` includes the
 GUI debugger.
 
 ## [CAFEBABE](http://littleosbook.github.io/#hello-cafebabe)
@@ -23,6 +31,8 @@ to be run.
 Run `make bochs` to build the project and launch bochs.
 
 ## Cross Compiler
+
+This cross-compiler should compile all the code we use in the repo. The makefile that download and builds it has been tested on Arch and OS X, and *should* generally work on any \*nix system.
 
 View the `Makefile` for all commands that need to
 be run.
@@ -37,4 +47,4 @@ This is really to make sure that your cross compiler
 worked. View the makefile for the commands that need
 to be run (requires `nasm` and `qemu` to work).
 
-Check out the link above for more details. 
+Check out the link above for more details.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ so the directions are targeted towards that OS.
 
 Arch:
 ```bash
-# pacman -S base-devel nasm cdrkit bochs multilib-devel
+# pacman -S base-devel nasm cdrtools bochs multilib-devel
 ```
 Mac:
 * Xcode with command line tools

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ $ brew install nasm cdrtools bochs
 ```
 NB: our cross-compiler compiled fine for me using clang, your mileage may vary. I have a lot of other libs on my system, not sure which are needed.
 
-`cdrtools` provides `genisoimage` and `bochs` includes the
+`cdrtools` provides `mkisofs` and `bochs` includes the
 GUI debugger.
 
 ## [CAFEBABE](http://littleosbook.github.io/#hello-cafebabe)

--- a/cafebabe/Makefile
+++ b/cafebabe/Makefile
@@ -13,16 +13,16 @@ iso/boot: kernel.elf
 	cp kernel.elf iso/boot
 
 os.iso: iso/boot iso/boot/grub
-	genisoimage -R                              \
-                -b boot/grub/stage2_eltorito    \
-                -no-emul-boot                   \
-                -boot-load-size 4               \
-                -A os                           \
-                -input-charset utf8             \
-                -quiet                          \
-                -boot-info-table                \
-                -o os.iso                       \
-                iso
+	mkisofs     -R                              \
+				-b boot/grub/stage2_eltorito    \
+				-no-emul-boot                   \
+				-boot-load-size 4               \
+				-A os                           \
+				-input-charset utf8             \
+				-quiet                          \
+				-boot-info-table                \
+				-o os.iso                       \
+				iso
 
 ## GRUB section
 $(GRUB).tar.gz:
@@ -37,7 +37,7 @@ stage2_eltorito:
 
 # KERNEL section
 kernel.elf: loader.o
-	ld -T link.ld -m elf_i386 loader.o -o kernel.elf
+	i686-elf-ld -T link.ld -m elf_i386 loader.o -o kernel.elf
 
 loader.o:
 	nasm -f elf32 loader.s

--- a/cafebabe/bochsrc.txt
+++ b/cafebabe/bochsrc.txt
@@ -1,7 +1,5 @@
 megs:            32
 display_library: x, options="gui_debug"
-romimage:        file=/usr/share/bochs/BIOS-bochs-latest
-vgaromimage:     file=/usr/share/bochs/VGABIOS-lgpl-latest
 ata0-master:     type=cdrom, path=os.iso, status=inserted
 boot:            cdrom
 log:             bochslog.txt


### PR DESCRIPTION
I've added instructions for OSX to the readme, switched the cafebaby makefile to use i686-elf-ld and mkisofs, and removed unused lines from bochsrc.txt.

@alexschneider Could you test this on Arch before merging this?
